### PR TITLE
fix(codepipeline): ensure sids are unique in single policy

### DIFF
--- a/codepipeline.tf
+++ b/codepipeline.tf
@@ -93,7 +93,7 @@ resource "aws_iam_policy" "codebuild" {
     "Version": "2012-10-17",
     "Statement": [
     {
-      "Sid": "AllowCodeBuildGitActions",
+      "Sid": "AllowCodeBuildGitPullActions",
       "Effect": "Allow",
       "Action": [
         "codecommit:GitPull"
@@ -101,7 +101,7 @@ resource "aws_iam_policy" "codebuild" {
       "Resource": "${aws_codecommit_repository.app.arn}"
     },
     {
-      "Sid": "AllowCodeBuildGitActions",
+      "Sid": "AllowCodeBuildGitPushActions",
       "Effect": "Allow",
       "Action": [
         "codecommit:GitPush"


### PR DESCRIPTION
To correct the following issue reported:

> Error: error creating IAM Policy xxx-yyy-codebuild-policy: MalformedPolicyDocument: Statement IDs (SID) in a single policy must be unique.
